### PR TITLE
Normalize demographic filtering ranges

### DIFF
--- a/src/hooks/useData.js
+++ b/src/hooks/useData.js
@@ -148,17 +148,18 @@ export function useData() {
       
       // Resetar filtros para estado inicial
       setFilters({
+        period: 'all',
+        questionnaire: 'all',
+        goals: {
+          QS: 4.0,
+          QO: 4.0,
+          QI: 4.0
+        },
         demographic: {
           sexo: [],
           idade: [],
           escolaridade: [],
-          funcionarioPublico: []
-        },
-        questionType: 'all',
-        goals: {
-          QS: 4.0,
-          QI: 4.0,
-          QO: 4.0
+          servidor: []
         }
       });
 
@@ -166,7 +167,8 @@ export function useData() {
       const newData = processedData;
       const isTransparency = newData.type === 'transparency';
       
-      console.log(`📊 Carregando dados do tipo: ${isTransparency ? 'Transparência (8 questões)' : 'Completo (20 questões)'}`);      console.log(`📈 Total de registros: ${newData.data.length}`);
+      console.log(`📊 Carregando dados do tipo: ${isTransparency ? 'Transparência (8 questões)' : 'Completo (20 questões)'}`);
+      console.log(`📈 Total de registros: ${newData.data.length}`);
       
       // SUBSTITUIÇÃO COMPLETA: Não manter dados anteriores
       const cleanData = {


### PR DESCRIPTION
## Summary
- align demographic filters with the UI age ranges by introducing shared helpers to normalize age buckets and servidor responses
- reuse the same normalization when building profile aggregates so charts and filters operate on matching demographic labels
- ensure text comparisons for sexo and escolaridade are case-insensitive to keep filtered dashboards populated

## Testing
- pnpm lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2df8f6a0832b9946c8ff69d84908

## Resumo por Sourcery

Normalizar os intervalos de filtragem demográfica e refatorar as funções de agregação para garantir rótulos de UI consistentes e operações que não diferenciam maiúsculas de minúsculas em toda a extração, filtragem e análise de dados.

Melhorias:
- Adicionar funções auxiliares para normalizar atributos demográficos (faixas etárias, texto, respostas do servidor).
- Atualizar a extração de dados de perfil e a filtragem demográfica para usar a normalização para correspondência que não diferencia maiúsculas de minúsculas e faixas etárias alinhadas à UI.
- Refatorar os cálculos de média de perguntas e dimensões para usar padrões de acumulador e retornar métricas enriquecidas (soma, contagem, média, dimensão, pergunta).
- Consolidar a lógica de classificação e recomendação para lidar com as novas estruturas de dados enriquecidas.
- Atualizar o estado inicial do filtro do hook useData (renomear filtro de servidor, adicionar período e questionário padrão) e limpar o console logging.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize demographic filtering ranges and refactor aggregation functions to ensure consistent UI labels and case-insensitive operations across data extraction, filtering, and analysis.

Enhancements:
- Add helpers for normalizing demographic attributes (age ranges, text, servidor responses).
- Update profile data extraction and demographic filtering to use normalization for case-insensitive matching and UI-aligned age buckets.
- Refactor question and dimension average calculations to use accumulator patterns and return enriched metrics (sum, count, average, dimension, question).
- Consolidate classification and recommendation logic to handle the new enriched data structures.
- Update useData hook initial filter state (rename servidor filter, add default period and questionnaire) and clean up console logging.

</details>